### PR TITLE
Add endpoints for Mrs_ml

### DIFF
--- a/testnets/daodiseotestnet/chain.json
+++ b/testnets/daodiseotestnet/chain.json
@@ -61,6 +61,10 @@
         "provider": "Stake Village"
       },
       {
+        "address": "https://daodiseo-testnet.rpc.mrsml.fun:443",
+        "provider": "Mrs_ml"
+      },
+      {
         "address": "https://rpc.YOURVALIDATOR.net",
         "provider": "YOUR_VALIDATOR_NAME"
       }
@@ -87,6 +91,10 @@
         "provider": "Stake Village"
       },
       {
+        "address": "https://daodiseo-testnet.api.mrsml.fun",
+        "provider": "Mrs_ml"
+      },
+      {
         "address": "https://api.YOURVALIDATOR.net",
         "provider": "YOUR_VALIDATOR_NAME"
       }
@@ -99,6 +107,10 @@
       {
         "address": "odiseo-testnet.grpc.stakevillage.net:443",
         "provider": "Stake Village"
+      },
+      {
+        "address": "daodiseo-testnet.grpc.mrsml.fun:443",
+        "provider": "Mrs_ml"
       }
     ]
   },


### PR DESCRIPTION
This PR adds the following endpoints for Mrs_ml validator on daodiseotestnet:
- RPC: https://daodiseo-testnet.rpc.mrsml.fun
- REST: https://daodiseo-testnet.api.mrsml.fun
- gRPC: daodiseo-testnet.grpc.mrsml.fun:443

Please let me know if any changes are required.